### PR TITLE
Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ludwig.egg*
+*.json

--- a/ludwig/__init__.py
+++ b/ludwig/__init__.py
@@ -1,3 +1,12 @@
+"""Ludwig
+
+Remote control mixing
+
+Ludwig offers a pluggable interface to control mixing software in realtime.
+
+It can run as a standalone server, or through a command line interface.
+"""
+
 from pluggy import HookimplMarker
 
 mixer = HookimplMarker('mixer')

--- a/ludwig/boards.py
+++ b/ludwig/boards.py
@@ -1,7 +1,7 @@
 from ludwig import mixer
 from ludwig.specs import Midi, Mixer
 from rtmidi.midiconstants import NOTE_ON, NOTE_OFF, CONTROL_CHANGE
-from pydantic import conint
+from ludwig.types import uint1, uint2, uint4, uint7, uint8, uint16
 from datetime import datetime
 
 class Qu24(Midi, Mixer):
@@ -20,32 +20,32 @@ class Qu24(Midi, Mixer):
         self.send(self.header + [0x12, 0x1, 0xF7])
     
     @mixer
-    def fader(self, channel:int, volume: int):
+    def fader(self, channel: uint7, volume: uint8):
         print(self.client_name, 'setting channel volume', channel, volume)
         self.nrpn(channel=channel, param=0x17, data1=volume, data2=0x7)
     
     @mixer
-    def pan(self, channel:int, pan: int):
+    def pan(self, channel: uint7, pan: uint8):
         self.nrpn(channel, 0x16, pan, 0x7)
     
     @mixer
-    def mute(self, channel:conint(ge=0, le=127)):
+    def mute(self, channel: uint7):
         self.send([NOTE_ON | self.channel, channel, 127])
     
     @mixer
-    def unmute(self, channel:conint(ge=0, le=127)):
+    def unmute(self, channel: uint7):
         self.send([NOTE_ON | self.channel, channel, 1])
     
     @mixer
     def compressor(self,
-            channel: int, 
-            type: int | None = None,
-            attack: int | None = None,
-            release: int | None = None,
-            knee: int | None = None,
-            ratio: int | None = None,
-            threshold: int | None = None,
-            gain: int | None = None):
+            channel: uint7, 
+            type: uint2 | None = None,
+            attack: uint7 | None = None,
+            release: uint7 | None = None,
+            knee: uint1 | None = None, 
+            ratio: uint7 | None = None,
+            threshold: uint7 | None = None,
+            gain: uint7 | None = None):
         if type:
             self.nrpn(channel, 0x61, type, 0x7)
         if attack:

--- a/ludwig/boards.py
+++ b/ludwig/boards.py
@@ -46,6 +46,21 @@ class Qu24(Midi, Mixer):
             ratio: uint7 | None = None,
             threshold: uint7 | None = None,
             gain: uint7 | None = None):
+        """send values to the compressor
+        
+        Reuqired arguments:
+            channel (uint7): MIDI channel
+        
+        Optional arguments:
+            type (uint2): 4 allowed types
+            attack (uint7): 300us to 300ms
+            release (uint7): 100ms to 2s
+            knee (uint1): 0 = hard, 1 = soft
+            ratio (uint7): 1:1 to inf (e.g. 2.6:1 = 80)
+            threshold (uint7): -46 to +18dB
+            gain (uint7): 0 +18dB
+        """
+        
         if type:
             self.nrpn(channel, 0x61, type, 0x7)
         if attack:

--- a/ludwig/boards.py
+++ b/ludwig/boards.py
@@ -64,7 +64,8 @@ class Qu24(Midi, Mixer):
     @mixer
     def close(self):
         from json import dump
-        with open(str(self.start_time) + '.json', 'w') as f:
+        from os.path import join
+        with open(join('logs', str(self.start_time) + '.json'), 'w') as f:
             dump(self.log, f)
     
     def __call__(self, event, data=None):

--- a/ludwig/boards.py
+++ b/ludwig/boards.py
@@ -60,14 +60,3 @@ class Qu24(Midi, Mixer):
             self.nrpn(channel, 0x66, threshold, 0x7)
         if gain:
             self.nrpn(channel, 0x67, gain, 0x7)
-    
-    @mixer
-    def close(self):
-        from json import dump
-        from os.path import join
-        with open(join('logs', str(self.start_time) + '.json'), 'w') as f:
-            dump(self.log, f)
-    
-    def __call__(self, event, data=None):
-        super().__call__(event, data)
-        self.log.append(event)

--- a/ludwig/boards.py
+++ b/ludwig/boards.py
@@ -1,7 +1,7 @@
 from ludwig import mixer
 from ludwig.specs import Midi, Mixer
 from rtmidi.midiconstants import NOTE_ON, NOTE_OFF, CONTROL_CHANGE
-from typing import Union
+from pydantic import conint
 from datetime import datetime
 
 class Qu24(Midi, Mixer):
@@ -13,11 +13,11 @@ class Qu24(Midi, Mixer):
 
     @mixer
     def allCall(self):
-        self.midi.send_message(self.header[:-1] + [0x7F] + [0x10, 0x0, 0xF7])
+        self.send(self.header[:-1] + [0x7F] + [0x10, 0x0, 0xF7])
     
     @mixer
     def meters(self):
-        self.midi.send_message(self.header + [0x12, 0x1, 0xF7])
+        self.send(self.header + [0x12, 0x1, 0xF7])
     
     @mixer
     def fader(self, channel:int, volume: int):
@@ -29,23 +29,23 @@ class Qu24(Midi, Mixer):
         self.nrpn(channel, 0x16, pan, 0x7)
     
     @mixer
-    def mute(self, channel:int):
-        self.midi.send_message([NOTE_ON | self.channel, channel, 127])
+    def mute(self, channel:conint(ge=0, le=127)):
+        self.send([NOTE_ON | self.channel, channel, 127])
     
     @mixer
-    def unmute(self, channel:int):
-        self.midi.send_message([NOTE_ON | self.channel, channel, 1])
+    def unmute(self, channel:conint(ge=0, le=127)):
+        self.send([NOTE_ON | self.channel, channel, 1])
     
     @mixer
     def compressor(self,
             channel: int, 
-            type: Union[int, None] = None,
-            attack: Union[int, None] = None,
-            release: Union[int, None] = None,
-            knee: Union[int, None] = None,
-            ratio: Union[int, None] = None,
-            threshold: Union[int, None] = None,
-            gain: Union[int, None] = None):
+            type: int | None = None,
+            attack: int | None = None,
+            release: int | None = None,
+            knee: int | None = None,
+            ratio: int | None = None,
+            threshold: int | None = None,
+            gain: int | None = None):
         if type:
             self.nrpn(channel, 0x61, type, 0x7)
         if attack:

--- a/ludwig/main.py
+++ b/ludwig/main.py
@@ -17,9 +17,9 @@ def main():
         parser.add_argument('channels', metavar='N', type=channel, nargs='+',
                             help='an integer for the accumulator')
         group = parser.add_mutually_exclusive_group()
-        group.add_argument('--mute', dest='mute', action='store_true',
+        group.add_argument('-m', '--mute', dest='mute', action='store_true',
                     help='mute the channel(s)')
-        group.add_argument('--unmute', dest='unmute', action='store_true',
+        group.add_argument('-u', '--unmute', dest='unmute', action='store_true',
                     help='unmute the channel(s)')
         args = parser.parse_args()
 

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -1,6 +1,5 @@
 from pluggy import HookspecMarker
 from rtmidi.midiutil import open_midioutput, open_midiinput
-from typing import Union
 from rtmidi.midiconstants import CONTROL_CHANGE
 
 mix = HookspecMarker('mixer')
@@ -21,14 +20,14 @@ class Mixer:
     @mix
     def compressor(self,
         channel: int, 
-        type: Union[int, None] = None,
-        attack: Union[int, None] = None,
-        release: Union[int, None] = None,
-        knee: Union[int, None] = None,
-        ratio: Union[int, None] = None,
-        threshold: Union[int, None] = None,
-        gain: Union[int, None] = None):
-        '''set the gain of the channel'''
+        type: int | None = None,
+        attack: int | None = None,
+        release: int | None = None,
+        knee: int | None = None,
+        ratio: int | None = None,
+        threshold: int | None = None,
+        gain: int | None = None):
+        '''set the compressor of the channel'''
     @mix
     def meters(self):
         '''get all meter values'''

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -1,7 +1,7 @@
 from pluggy import HookspecMarker
 from rtmidi.midiutil import open_midioutput, open_midiinput
 from rtmidi.midiconstants import CONTROL_CHANGE
-
+from pydantic import conint
 mix = HookspecMarker('mixer')
 
 class Mixer:
@@ -46,11 +46,14 @@ class Midi:
         self.input.ignore_types(sysex=False)
         self.input.set_callback(self)
     
+    def send(self, message: list[conint(ge=0, lt=256)]):
+        self.midi.send_message(message)
+
     def nrpn(self, channel, param, data1, data2):
-        self.midi.send_message([CONTROL_CHANGE | self.channel, 0x63, channel])
-        self.midi.send_message([CONTROL_CHANGE | self.channel, 0x62, param])
-        self.midi.send_message([CONTROL_CHANGE | self.channel, 0x6, data1])
-        self.midi.send_message([CONTROL_CHANGE | self.channel, 0x26, data2])
+        self.send([CONTROL_CHANGE | self.channel, 0x63, channel])
+        self.send([CONTROL_CHANGE | self.channel, 0x62, param])
+        self.send([CONTROL_CHANGE | self.channel, 0x6, data1])
+        self.send([CONTROL_CHANGE | self.channel, 0x26, data2])
     
     def __call__(self, event, data=None):
         message, deltatime = event

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -7,16 +7,16 @@ mix = HookspecMarker('mixer')
 class Mixer:
     @mix
     def mute(self, channel: int):
-        '''mute channel'''
+        """mute channel"""
     @mix
     def unmute(self, channel: int):
-        '''unmute channel'''
+        """unmute channel"""
     @mix
     def fader(self, channel: int, volume: int):
-        '''set the fader volume of a channel'''
+        """set the fader volume of a channel"""
     @mix
     def pan(self, channel: int, pan: int):
-        '''set pan of the channel'''
+        """set pan of the channel"""
     @mix
     def compressor(self,
         channel: int, 
@@ -27,13 +27,13 @@ class Mixer:
         ratio: int | None = None,
         threshold: int | None = None,
         gain: int | None = None):
-        '''set the compressor of the channel'''
+        """set the compressor of the channel"""
     @mix
     def meters(self):
-        '''get all meter values'''
+        """get all meter values"""
     @mix
     def allCall(self):
-        '''get full board status'''
+        """get full board status"""
     
 
 class Midi:
@@ -47,9 +47,11 @@ class Midi:
         self.input.set_callback(self)
     
     def send(self, message: list[conint(ge=0, lt=256)]):
+        """send a regular MIDI message"""
         self.midi.send_message(message)
 
     def nrpn(self, channel, param, data1, data2):
+        """send a MIDI Non-Registered Parameter Number"""
         self.send([CONTROL_CHANGE | self.channel, 0x63, channel])
         self.send([CONTROL_CHANGE | self.channel, 0x62, param])
         self.send([CONTROL_CHANGE | self.channel, 0x6, data1])

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -1,7 +1,8 @@
 from pluggy import HookspecMarker
 from rtmidi.midiutil import open_midioutput, open_midiinput
 from rtmidi.midiconstants import CONTROL_CHANGE
-from pydantic import conint
+from ludwig.types import uint4, uint7, uint8, uint16
+
 mix = HookspecMarker('mixer')
 
 class Mixer:
@@ -37,7 +38,13 @@ class Mixer:
     
 
 class Midi:
-    def __init__(self, *args, port, client_name='midi', channel=0, input_name=None, **kwargs):
+    def __init__(self, 
+            *args,
+            port: str,
+            client_name: str = 'midi',
+            channel: uint4 = 0,
+            input_name: str | None = None,
+            **kwargs):
         self.port = port
         self.client_name = client_name
         self.channel = channel
@@ -46,11 +53,15 @@ class Midi:
         self.input.ignore_types(sysex=False)
         self.input.set_callback(self)
     
-    def send(self, message: list[conint(ge=0, lt=256)]):
+    def send(self, message: list[uint8]):
         """send a regular MIDI message"""
         self.midi.send_message(message)
 
-    def nrpn(self, channel, param, data1, data2):
+    def nrpn(self, 
+            channel: uint7,
+            param: uint8,
+            data1: uint8,
+            data2: uint8):
         """send a MIDI Non-Registered Parameter Number"""
         self.send([CONTROL_CHANGE | self.channel, 0x63, channel])
         self.send([CONTROL_CHANGE | self.channel, 0x62, param])

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -36,6 +36,10 @@ class Mixer:
     def allCall(self):
         """get full board status"""
     
+    @mix
+    def close(self):
+        """close the midi connection"""
+    
 
 class Midi:
     def __init__(self, 

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -6,6 +6,7 @@ from ludwig.types import uint4, uint7, uint8, uint16
 mix = HookspecMarker('mixer')
 
 class Mixer:
+    """A generic mixer class, to be overwritten by individual boards"""
     @mix
     def mute(self, channel: int):
         """mute channel"""
@@ -49,6 +50,17 @@ class Midi:
             channel: uint4 = 0,
             input_name: str | None = None,
             **kwargs):
+        """A generic MIDI connection class
+        attributes:
+            port (str): the name of the MIDI port
+            client_name (str): the name of the MIDI client to be connected
+            channel (int): the MIDI channel to communicate on (default = 0)
+            input_name (str): a custom name for the input client
+        methods:
+            send(message): send a MIDI message of bytes (sent as integers)
+            nrpm(message): send a MIDI NRPN (Non-Registered Parameter Number)
+        """
+        
         self.port = port
         self.client_name = client_name
         self.channel = channel

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -79,10 +79,11 @@ class Midi:
             data1: uint8,
             data2: uint8):
         """send a MIDI Non-Registered Parameter Number"""
-        self.send([CONTROL_CHANGE | self.channel, 0x63, channel])
-        self.send([CONTROL_CHANGE | self.channel, 0x62, param])
-        self.send([CONTROL_CHANGE | self.channel, 0x6, data1])
-        self.send([CONTROL_CHANGE | self.channel, 0x26, data2])
+        header = CONTROL_CHANGE | self.channel
+        self.send([header, 0x63, channel])
+        self.send([header, 0x62, param])
+        self.send([header, 0x6, data1])
+        self.send([header, 0x26, data2])
     
     def __call__(self, event, data=None):
         message, deltatime = event

--- a/ludwig/types.py
+++ b/ludwig/types.py
@@ -1,0 +1,14 @@
+"""types
+
+Custom types for validation
+"""
+
+from pydantic import conint
+
+# unsigned integers
+uint1 = conint(ge=0, lt=2)
+uint2 = conint(ge=0, lt=4)
+uint4 = conint(ge=0, lt=16)
+uint7 = conint(ge=0, lt=128)
+uint8 = conint(ge=0, lt=256)
+uint16 = conint(ge=0, lt=2**16)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ from setuptools import setup, find_packages
 
 setup(
     name='ludwig',
-    install_requires='pluggy>=0.3,<1.0',
+    install_requires=[
+        'pluggy>=0.3,<1.0',
+        'python-rtmidi>=1.4.9,<1.5.0'
+    ],
     entry_points={'console_scripts': ['ludwig=ludwig.main:main']},
     packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ setup(
     name='ludwig',
     install_requires=[
         'pluggy>=0.3,<1.0',
-        'python-rtmidi>=1.4.9,<1.5.0'
+        'python-rtmidi>=1.4.9,<1.5.0',
+        'pydantic>=1.9.0,<1.10.0',
     ],
     entry_points={'console_scripts': ['ludwig=ludwig.main:main']},
     packages=find_packages(),


### PR DESCRIPTION
# Update
update code to include types and docstrings

## docstrings
- converted all docstrings to use triple double quotes `"""`
- added descriptions to parameters
- added top level documentation in `__init__.py`

##  types
- added types to function signatures
  - `@mix` uses `int`
    - allows boards to patch with custom types
  - `boards.Qu24` validates uses uint8 types
    - prevents accidental MIDI overflow messages, which could create undesirable effects on the mixer 
- custom types
  - `uint` types: unsigned integers
    -  using `pydantic.conint`
    - `uint1` unsigned 1 bit number (0 or 1)
    - `uint8` unsigned 8 bit number (0 to 255)

## misc
- removed simplistic logging
- added short cli args for `mute` and `unmute`
- migrated to `Midi.send` method to validate all MIDI messages
- updated install_requires to include pydantic and python-midi