### PR TITLE
format code with black --skip-string-normalization

### DIFF
--- a/ludwig/boards.py
+++ b/ludwig/boards.py
@@ -4,53 +4,56 @@ from rtmidi.midiconstants import NOTE_ON, NOTE_OFF, CONTROL_CHANGE
 from ludwig.types import uint1, uint2, uint4, uint7, uint8, uint16
 from datetime import datetime
 
+
 class Qu24(Midi, Mixer):
     def __init__(self, *args, **kwargs):
         super().__init__(self, *args, **kwargs)
-        self.header = [0xF0 , 0x0 , 0x0 , 0x1A , 0x50 , 0x11 , 0x1 , 0x0 , self.channel]
+        self.header = [0xF0, 0x0, 0x0, 0x1A, 0x50, 0x11, 0x1, 0x0, self.channel]
         self.start_time = datetime.now()
         self.log = []
 
     @mixer
     def allCall(self):
         self.send(self.header[:-1] + [0x7F] + [0x10, 0x0, 0xF7])
-    
+
     @mixer
     def meters(self):
         self.send(self.header + [0x12, 0x1, 0xF7])
-    
+
     @mixer
     def fader(self, channel: uint7, volume: uint8):
         print(self.client_name, 'setting channel volume', channel, volume)
         self.nrpn(channel=channel, param=0x17, data1=volume, data2=0x7)
-    
+
     @mixer
     def pan(self, channel: uint7, pan: uint8):
         self.nrpn(channel, 0x16, pan, 0x7)
-    
+
     @mixer
     def mute(self, channel: uint7):
         self.send([NOTE_ON | self.channel, channel, 127])
-    
+
     @mixer
     def unmute(self, channel: uint7):
         self.send([NOTE_ON | self.channel, channel, 1])
-    
+
     @mixer
-    def compressor(self,
-            channel: uint7, 
-            type: uint2 | None = None,
-            attack: uint7 | None = None,
-            release: uint7 | None = None,
-            knee: uint1 | None = None, 
-            ratio: uint7 | None = None,
-            threshold: uint7 | None = None,
-            gain: uint7 | None = None):
+    def compressor(
+        self,
+        channel: uint7,
+        type: uint2 | None = None,
+        attack: uint7 | None = None,
+        release: uint7 | None = None,
+        knee: uint1 | None = None,
+        ratio: uint7 | None = None,
+        threshold: uint7 | None = None,
+        gain: uint7 | None = None,
+    ):
         """send values to the compressor
-        
+
         Reuqired arguments:
             channel (uint7): MIDI channel
-        
+
         Optional arguments:
             type (uint2): 4 allowed types
             attack (uint7): 300us to 300ms
@@ -60,7 +63,7 @@ class Qu24(Midi, Mixer):
             threshold (uint7): -46 to +18dB
             gain (uint7): 0 +18dB
         """
-        
+
         if type:
             self.nrpn(channel, 0x61, type, 0x7)
         if attack:

--- a/ludwig/main.py
+++ b/ludwig/main.py
@@ -2,25 +2,40 @@ from ludwig.specs import Mixer
 from ludwig.boards import Qu24
 from pluggy import PluginManager
 from argparse import ArgumentTypeError
+
+
 def channel(n: int):
     n = int(n)
-    if n>109:
+    if n > 109:
         raise ArgumentTypeError('invalid QU channel number')
     else:
         return n
+
 
 def main():
     pm = get_plugin_manager()
     try:
         from argparse import ArgumentParser
+
         parser = ArgumentParser(description='remote sound board operation')
-        parser.add_argument('channels', metavar='N', type=channel, nargs='+',
-                            help='an integer for the accumulator')
+        parser.add_argument(
+            'channels',
+            metavar='N',
+            type=channel,
+            nargs='+',
+            help='an integer for the accumulator',
+        )
         group = parser.add_mutually_exclusive_group()
-        group.add_argument('-m', '--mute', dest='mute', action='store_true',
-                    help='mute the channel(s)')
-        group.add_argument('-u', '--unmute', dest='unmute', action='store_true',
-                    help='unmute the channel(s)')
+        group.add_argument(
+            '-m', '--mute', dest='mute', action='store_true', help='mute the channel(s)'
+        )
+        group.add_argument(
+            '-u',
+            '--unmute',
+            dest='unmute',
+            action='store_true',
+            help='unmute the channel(s)',
+        )
         args = parser.parse_args()
 
         args = parser.parse_args()
@@ -36,6 +51,7 @@ def main():
         print(e)
     finally:
         pm.hook.close()
+
 
 def get_plugin_manager():
     pm = PluginManager('mixer')

--- a/ludwig/specs.py
+++ b/ludwig/specs.py
@@ -5,51 +5,63 @@ from ludwig.types import uint4, uint7, uint8, uint16
 
 mix = HookspecMarker('mixer')
 
+
 class Mixer:
     """A generic mixer class, to be overwritten by individual boards"""
+
     @mix
     def mute(self, channel: int):
         """mute channel"""
+
     @mix
     def unmute(self, channel: int):
         """unmute channel"""
+
     @mix
     def fader(self, channel: int, volume: int):
         """set the fader volume of a channel"""
+
     @mix
     def pan(self, channel: int, pan: int):
         """set pan of the channel"""
+
     @mix
-    def compressor(self,
-        channel: int, 
+    def compressor(
+        self,
+        channel: int,
         type: int | None = None,
         attack: int | None = None,
         release: int | None = None,
         knee: int | None = None,
         ratio: int | None = None,
         threshold: int | None = None,
-        gain: int | None = None):
+        gain: int | None = None,
+    ):
         """set the compressor of the channel"""
+
     @mix
     def meters(self):
         """get all meter values"""
+
     @mix
     def allCall(self):
         """get full board status"""
-    
+
     @mix
     def close(self):
         """close the midi connection"""
-    
+
 
 class Midi:
-    def __init__(self, 
-            *args,
-            port: str,
-            client_name: str = 'midi',
-            channel: uint4 = 0,
-            input_name: str | None = None,
-            **kwargs):
+    def __init__(
+        self,
+        *args,
+        port: str,
+        client_name: str = 'midi',
+        channel: uint4 = 0,
+        input_name: str | None = None,
+        **kwargs
+    ):
         """A generic MIDI connection class
         attributes:
             port (str): the name of the MIDI port
@@ -60,31 +72,31 @@ class Midi:
             send(message): send a MIDI message of bytes (sent as integers)
             nrpm(message): send a MIDI NRPN (Non-Registered Parameter Number)
         """
-        
+
         self.port = port
         self.client_name = client_name
         self.channel = channel
-        self.midi, self.name = open_midioutput(port, client_name=client_name+'-output')
-        self.input, self.input_name = open_midiinput(input_name if input_name else port, client_name=client_name+'-input')
+        self.midi, self.name = open_midioutput(
+            port, client_name=client_name + '-output'
+        )
+        self.input, self.input_name = open_midiinput(
+            input_name if input_name else port, client_name=client_name + '-input'
+        )
         self.input.ignore_types(sysex=False)
         self.input.set_callback(self)
-    
+
     def send(self, message: list[uint8]):
         """send a regular MIDI message"""
         self.midi.send_message(message)
 
-    def nrpn(self, 
-            channel: uint7,
-            param: uint8,
-            data1: uint8,
-            data2: uint8):
+    def nrpn(self, channel: uint7, param: uint8, data1: uint8, data2: uint8):
         """send a MIDI Non-Registered Parameter Number"""
         header = CONTROL_CHANGE | self.channel
         self.send([header, 0x63, channel])
         self.send([header, 0x62, param])
         self.send([header, 0x6, data1])
         self.send([header, 0x26, data2])
-    
+
     def __call__(self, event, data=None):
         message, deltatime = event
         print(self.client_name, message, deltatime)


### PR DESCRIPTION
# Black
Use [black](https://black.readthedocs.io/) formatting to conform to PEP standards.

Uses: `--skip-string-normalization` to avoid converting `'` to `"`

Can be run directly with `black --skip-string-normalization *.py` or can be integrated into IDE to run on save.